### PR TITLE
0.7.1 beta

### DIFF
--- a/DialogueDisplayFramework.csproj
+++ b/DialogueDisplayFramework.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>0.7.1</Version>
     <TargetFramework>net6.0</TargetFramework>
     <EnableHarmony>true</EnableHarmony>
     <Platforms>AnyCPU;x64</Platforms>

--- a/Framework/Data/GiftsData.cs
+++ b/Framework/Data/GiftsData.cs
@@ -2,11 +2,11 @@
 {
     public class GiftsData : BaseData, IGiftsData
     {
-        public bool ShowGiftIcon { get; set; }
+        public float IconScale { get; set; }
         public bool Inline { get; set; }
         public GiftsData()
         {
-            ShowGiftIcon = true;
+            IconScale = 1f;
         }
     }
 }

--- a/Framework/DialogueBoxInterface.cs
+++ b/Framework/DialogueBoxInterface.cs
@@ -12,6 +12,8 @@ namespace DialogueDisplayFramework.Framework
         public static bool preventGetCurrentString;
         private static Dictionary<string, DialogueDisplayData> cachedDialogueData = new();
 
+        public static bool appliedBoxSize = false;
+
         // Reflection
         public static IReflectedMethod shouldPortraitShake;
 

--- a/Framework/DialogueBoxRenderer.cs
+++ b/Framework/DialogueBoxRenderer.cs
@@ -273,7 +273,7 @@ namespace DialogueDisplayFramework.Framework
         {
             ApiConsumerManager.RaiseRenderingJewel(b, dialogueBox, jewel);
 
-            if (dialogueBox.shouldDrawFriendshipJewel() && jewel?.Disabled == false)
+            if (ShouldDrawFriendshipJewel(dialogueBox) && jewel?.Disabled == false)
             {
                 var pos = GetDataVector(dialogueBox, jewel);
                 var friendshipHeartLevel = friendship.Points / 250;
@@ -329,6 +329,13 @@ namespace DialogueDisplayFramework.Framework
         public static Vector2 GetDataVector(DialogueBox box, BaseData data)
         {
             return new Vector2(box.x + (data.Right ? box.width : 0) + data.XOffset, box.y + (data.Bottom ? box.height : 0) + data.YOffset);
+        }
+
+        // Extracted from StardewValley.Menus.DialogueBox.shouldDrawFriendshipJewel v1.6.15
+        // Support for SMAPI for Android
+        public static bool ShouldDrawFriendshipJewel(DialogueBox dlg)
+        {
+            return (dlg.width >= 642 && !Game1.eventUp && !dlg.isQuestion && dlg.isPortraitBox() && !dlg.friendshipJewel.Equals(Rectangle.Empty) && dlg.characterDialogue?.speaker != null && Game1.player.friendshipData.ContainsKey(dlg.characterDialogue.speaker.Name) && dlg.characterDialogue.speaker.Name != "Henchman");
         }
     }
 }

--- a/Framework/DialogueBoxRenderer.cs
+++ b/Framework/DialogueBoxRenderer.cs
@@ -279,7 +279,7 @@ namespace DialogueDisplayFramework.Framework
                 Rectangle sourceRect;
 
                 if (friendshipHeartLevel >= 10)
-                    sourceRect = new Rectangle(269, 494, 11, 11);
+                    sourceRect = new Rectangle(269, 495, 11, 11);
                 else
                 {
                     var animationFrame = (int)(Game1.currentGameTime.TotalGameTime.TotalMilliseconds % 1000.0 / 250.0);

--- a/Framework/DialogueBoxRenderer.cs
+++ b/Framework/DialogueBoxRenderer.cs
@@ -236,9 +236,34 @@ namespace DialogueDisplayFramework.Framework
             if (gifts?.Disabled == false && !friendship.IsMarried() && speaker is not Child)
             {
                 var pos = GetDataVector(dialogueBox, gifts);
-                Utility.drawWithShadow(b, Game1.mouseCursors2, pos + new Vector2(6, 0), new Rectangle(166, 174, 14, 12), Color.White, 0f, Vector2.Zero, 4f, false, 0.88f, 0, -1, 0.2f);
-                b.Draw(Game1.mouseCursors, pos + (gifts.Inline ? new Vector2(64, 8) : new Vector2(0, 56)), new Rectangle?(new Rectangle(227 + ((Game1.player.friendshipData[speaker.Name].GiftsThisWeek >= 2) ? 9 : 0), 425, 9, 9)), Color.White, 0f, Vector2.Zero, 4f, SpriteEffects.None, 0.88f);
-                b.Draw(Game1.mouseCursors, pos + (gifts.Inline ? new Vector2(96, 8) : new Vector2(32, 56)), new Rectangle?(new Rectangle(227 + (Game1.player.friendshipData[speaker.Name].GiftsThisWeek >= 1 ? 9 : 0), 425, 9, 9)), Color.White, 0f, Vector2.Zero, 4f, SpriteEffects.None, 0.88f);
+
+                var giftsThisWeek = Game1.player.friendshipData[speaker.Name].GiftsThisWeek;
+                var iconRealScale = gifts.IconScale * gifts.Scale;
+
+                var iconRect = new Rectangle(166, 174, 14, 12);
+                var emptyBoxRect = new Rectangle(227, 425, 9, 9);
+                var checkmarkRect = new Rectangle(236, 425, 9, 9);
+
+                if (gifts.IconScale > 0)
+                {
+                    var offset = Vector2.Zero;
+                    if (gifts.Inline)
+                        offset.Y = (iconRect.Height - iconRect.Height * gifts.IconScale) / 2f * gifts.Scale;
+                    else
+                        offset.X = (checkmarkRect.Width * 2 - iconRect.Width * gifts.IconScale - 1) / 2f * gifts.Scale;
+
+                    Utility.drawWithShadow(b, Game1.mouseCursors2, pos + offset, iconRect, Color.White, 0f, Vector2.Zero, iconRealScale, false, 0.88f, 0, -1, 0.2f);
+                    pos += (gifts.Inline ? new Vector2(iconRect.Width, 0) : new Vector2(0, iconRect.Height)) * iconRealScale;
+                }
+
+                // TODO: add padding option?
+                pos += new Vector2(gifts.Inline ? 1 : 0, 2) * gifts.Scale;
+
+                for (var i = 1; i >= 0; i--) // First checkmark is placed to the right
+                {
+                    b.Draw(Game1.mouseCursors, pos, giftsThisWeek > i ? checkmarkRect : emptyBoxRect, Color.White, 0f, Vector2.Zero, gifts.Scale, SpriteEffects.None, 0.88f);
+                    pos.X += (checkmarkRect.Width - 1) * gifts.Scale;
+                }
             }
 
             ApiConsumerManager.RaiseRenderedGifts(b, dialogueBox, gifts);

--- a/Framework/DialogueBoxRenderer.cs
+++ b/Framework/DialogueBoxRenderer.cs
@@ -275,18 +275,26 @@ namespace DialogueDisplayFramework.Framework
 
             if (dialogueBox.shouldDrawFriendshipJewel() && jewel?.Disabled == false)
             {
+                var pos = GetDataVector(dialogueBox, jewel);
                 var friendshipHeartLevel = friendship.Points / 250;
                 Rectangle sourceRect;
 
                 if (friendshipHeartLevel >= 10)
+                {
                     sourceRect = new Rectangle(269, 495, 11, 11);
+                }
                 else
                 {
                     var animationFrame = (int)(Game1.currentGameTime.TotalGameTime.TotalMilliseconds % 1000.0 / 250.0);
                     sourceRect = new Rectangle(140 + animationFrame * 11, 532 + friendshipHeartLevel / 2 * 11, 11, 11);
                 }
 
-                b.Draw(Game1.mouseCursors, GetDataVector(dialogueBox, jewel), sourceRect, Color.White * jewel.Alpha, 0f, Vector2.Zero, jewel.Scale, SpriteEffects.None, jewel.LayerDepth);
+                b.Draw(Game1.mouseCursors, pos, sourceRect, Color.White * jewel.Alpha, 0f, Vector2.Zero, jewel.Scale, SpriteEffects.None, jewel.LayerDepth);
+
+                dialogueBox.friendshipJewel = new Rectangle((int)pos.X, (int)pos.Y, (int)(11 * jewel.Scale), (int)(11 * jewel.Scale));
+            } else
+            {
+                dialogueBox.friendshipJewel = Rectangle.Empty;
             }
 
             ApiConsumerManager.RaiseRenderedJewel(b, dialogueBox, jewel);

--- a/IDialogueDisplayApi.cs
+++ b/IDialogueDisplayApi.cs
@@ -220,8 +220,8 @@ namespace DialogueDisplayFramework
 
     public interface IGiftsData : IBaseData
     {
-        /// <summary>Whether to display the gift icon.</summary>
-        public bool ShowGiftIcon { get; set; }
+        /// <summary>Scale of the gift icon (default 1).</summary>
+        public float IconScale { get; set; }
 
         /// <summary>Whether to place the check boxes next to eachother.</summary>
         public bool Inline { get; set; }

--- a/docs/api.md
+++ b/docs/api.md
@@ -316,6 +316,7 @@ Along the [common data fields](#common-data-fields), gift data includes the foll
 
 | Key            | Type    | Description |
 | -------------- | ------- | ----------- |
+| `iconScale`    | decimal | Scale specific to the gift icon, default 1. Set to 0 to hide. Multiplied by `scale`.
 | `inline`       | boolean | If true, the check boxes are placed to the right of the gift icon, otherwise it's placed underneath, default false.
 
 

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -5,6 +5,7 @@
  * Fixed scale not affecting gift components.
  * Fixed misaligned friendship jewel.
  * Fixed sized boxes also applying to question boxes.
+ * Fixed misplaced friendship jewel tooltip.
 
 ## 0.7.0
 * Introduced an API that allows mods to access the framework's data and render methods.

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -6,6 +6,7 @@
  * Fixed misaligned friendship jewel.
  * Fixed sized boxes also applying to question boxes.
  * Fixed misplaced friendship jewel tooltip.
+ * Fixed an incompatible method missing from SMAPI for Android. Please report further issues.
 
 ## 0.7.0
 * Introduced an API that allows mods to access the framework's data and render methods.

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -1,5 +1,9 @@
 # Changelogs
 
+## 0.7.1
+ * Added an `iconScale` option to `gifts` to scale the icon independently of the checkmarks.
+ * Fixed scale not affecting gift components.
+
 ## 0.7.0
 * Introduced an API that allows mods to access the framework's data and render methods.
 * Fixed a crash when the `dialogue` field was set to null, again.

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -3,6 +3,7 @@
 ## 0.7.1
  * Added an `iconScale` option to `gifts` to scale the icon independently of the checkmarks.
  * Fixed scale not affecting gift components.
+ * Fixed misaligned friendship jewel.
 
 ## 0.7.0
 * Introduced an API that allows mods to access the framework's data and render methods.

--- a/docs/changelogs.md
+++ b/docs/changelogs.md
@@ -4,6 +4,7 @@
  * Added an `iconScale` option to `gifts` to scale the icon independently of the checkmarks.
  * Fixed scale not affecting gift components.
  * Fixed misaligned friendship jewel.
+ * Fixed sized boxes also applying to question boxes.
 
 ## 0.7.0
 * Introduced an API that allows mods to access the framework's data and render methods.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "Name": "Dialogue Display Framework Continued",
   "Author": "Mangupix",
-  "Version": "0.7.0",
+  "Version": "0.7.1",
   "Description": "Framework allowing mods to edit the dialogue box.",
   "UniqueID": "Mangupix.DialogueDisplayFrameworkContinued",
   "EntryDll": "DialogueDisplayFramework.dll",


### PR DESCRIPTION
 * Added an `iconScale` option to `gifts` to scale the icon independently of the checkmarks.
 * Fixed scale not affecting gift components.
 * Fixed misaligned friendship jewel.
 * Fixed sized boxes also applying to question boxes.
 * Fixed misplaced friendship jewel tooltip.
 * Fixed an incompatible method missing from SMAPI for Android. Please report further issues.